### PR TITLE
fix: Ensure non-negative values for Current Consumption

### DIFF
--- a/src/abilities/power-meter.ts
+++ b/src/abilities/power-meter.ts
@@ -87,9 +87,14 @@ export class PowerMeterAbility extends Ability {
    * Handles changes to the `apower` property.
    */
   protected apowerChangeHandler(value: ShelliesCharacteristicValue) {
+    /**
+     * Handles changes to the 'apower' property. HomeKit does not support negative values for the 'Current Consumption' characteristic.
+     * For the use case of this plugin, knowing the negative voltage is not necessary, so we ensure that the value is never negative.
+     */
+    const positiveValue = Math.max(0, value as number); 
     this.service.updateCharacteristic(
-      this.customCharacteristics.CurrentConsumption,
-      value as number,
+        this.customCharacteristics.CurrentConsumption,
+        positiveValue,
     );
   }
 


### PR DESCRIPTION
[I have an issue where my log is spammed by warnings of negative values from my photovoltaic. ](https://github.com/alexryd/homebridge-shelly-ng/issues/115)

It seems like this is the most up-to-date version of the plugin. So, I will try to fix this issue with a pull request here (before I create yet my own .. ). 

A perfect solution would involve an additional flag if it is a positive or a negative value like https://github.com/maloo0/homebridge-shelly-consumption is doing. But this is above my knowledge. 