### PR TITLE
Add Pro Dimmer 1PM and 2PM

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,21 +13,23 @@ For the first generation, see [homebridge-shelly](https://github.com/alexryd/hom
 
 ## Supported devices
 
-* [Shelly Plus 1](https://shelly.cloud/shelly-plus-1/)
-* [Shelly Plus 1 PM](https://shelly.cloud/shelly-plus-1pm/)
-* [Shelly Plus 1 Mini](https://shelly-api-docs.shelly.cloud/gen2/Devices/ShellyPlus1)
-* [Shelly Plus 1 PM Mini](https://shelly-api-docs.shelly.cloud/gen2/Devices/ShellyPlus1PM)
-* [Shelly Plus PM Mini](https://shelly-api-docs.shelly.cloud/gen2/Devices/ShellyPlusPMMini)
-* [Shelly Plus 2 PM](https://shelly.cloud/shelly-plus-2pm/)
-* [Shelly Plus I4](https://shelly.cloud/shelly-plus-i4/)
-* [Shelly Plus Plug US](https://shelly.cloud/shelly-plus-plug-us/)
-* [Shelly Plus Plug S](https://www.shelly.com/de/products/shop/shelly-plus-plug-s-1/)
-* [Shelly Pro 1](https://shelly.cloud/shelly-pro-smart-home-automation-solution/)
-* [Shelly Pro 1 PM](https://shelly.cloud/shelly-pro-smart-home-automation-solution/)
-* [Shelly Pro 2](https://shelly.cloud/shelly-pro-smart-home-automation-solution/)
-* [Shelly Pro 2 PM](https://shelly.cloud/shelly-pro-smart-home-automation-solution/)
-* [Shelly Pro 3](https://shelly.cloud/shelly-pro-smart-home-automation-solution/)
-* [Shelly Pro 4 PM](https://shelly.cloud/shelly-pro-smart-home-automation-solution/)
+* [Shelly Plus 1](https://kb.shelly.cloud/knowledge-base/shelly-plus-1)
+* [Shelly Plus 1 PM](https://kb.shelly.cloud/knowledge-base/shelly-plus-1pm)
+* [Shelly Plus 1 Mini](https://kb.shelly.cloud/knowledge-base/shelly-plus-1-mini)
+* [Shelly Plus 1 PM Mini](https://kb.shelly.cloud/knowledge-base/shelly-plus-1pm-mini)
+* [Shelly Plus PM Mini](https://kb.shelly.cloud/knowledge-base/shelly-plus-pm-mini)
+* [Shelly Plus 2 PM](https://kb.shelly.cloud/knowledge-base/shelly-plus-2pm)
+* [Shelly Plus i4](https://kb.shelly.cloud/knowledge-base/shelly-plus-i4)
+* [Shelly Plus Plug US](https://kb.shelly.cloud/knowledge-base/shelly-plus-plug-us)
+* [Shelly Plus Plug S](https://kb.shelly.cloud/knowledge-base/shelly-plus-plug-s-1)
+* [Shelly Pro 1](https://kb.shelly.cloud/knowledge-base/shelly-pro-1)
+* [Shelly Pro 1 PM](https://kb.shelly.cloud/knowledge-base/shelly-pro-1pm)
+* [Shelly Pro 2](https://kb.shelly.cloud/knowledge-base/shelly-pro-2)
+* [Shelly Pro 2 PM](https://kb.shelly.cloud/knowledge-base/shelly-pro-2pm)
+* [Shelly Pro 3](https://kb.shelly.cloud/knowledge-base/shelly-pro-3-v1)
+* [Shelly Pro 4 PM](https://kb.shelly.cloud/knowledge-base/shelly-pro-4pm)
+* [Shelly Pro Dimmer 1PM](https://kb.shelly.cloud/knowledge-base/shelly-pro-dimmer-1pm)
+* [Shelly Pro Dimmer 2PM](https://kb.shelly.cloud/knowledge-base/shelly-pro-dimmer-2pm)
 
 ## Installation
 
@@ -110,6 +112,7 @@ See below for descriptions of each configuration option.
 | `devices. switch:0-3.type`      | The type of accessory used to represent the switch with the specified index number. Available options are `"outlet"` and `"switch"` (default).
 | `devices. cover:0.exclude`      | Set this option to `true` to prevent this cover from being added to HomeKit. |
 | `devices. cover:0.type`         | Only available for devices in cover mode. The type of accessory used to represent the cover. Available options are `"door"`, `"window"` (default) and `"windowCovering"`.
+| `devices. light:0.exclude`      | Set this option to `true` to prevent this light from being added to HomeKit. |
 | `mdns`                          | Settings for the mDNS device discovery service. |
 | `mdns. enable`                  | Set this option to `false` to disable automatic device discovery using mDNS. |
 | `mdns. interface`               | The network interface to use when sending and receiving mDNS packets. You probably don't need to use this setting unless you know what you're doing. If not specified, all available network interfaces will be used. |

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.1.2",
       "license": "GPL-3.0",
       "dependencies": {
-        "shellies-ds9": "^1.0.5"
+        "shellies-ds9": "^1.0.6"
       },
       "devDependencies": {
         "@types/jest": "^29.5.11",
@@ -29,6 +29,37 @@
       "engines": {
         "homebridge": ">=1.3.5",
         "node": ">=14.18.3"
+      },
+      "funding": {
+        "type": "kofi",
+        "url": "https://ko-fi.com/cubi1337"
+      }
+    },
+    "../node-shellies-ds9": {
+      "name": "shellies-ds9",
+      "version": "1.0.6",
+      "license": "GPL-3.0",
+      "dependencies": {
+        "@types/multicast-dns": "^7.2.4",
+        "eventemitter3": "^5.0.1",
+        "fast-deep-equal": "^3.1.3",
+        "homebridge-shelly-ds9": "file:../homebridge-shelly-ds9",
+        "json-rpc-2.0": "^1.7.0",
+        "multicast-dns": "^7.2.5",
+        "ws": "^8.14.2"
+      },
+      "devDependencies": {
+        "@types/jest": "^29.5.11",
+        "@typescript-eslint/eslint-plugin": "^6.13.2",
+        "@typescript-eslint/parser": "^6.13.2",
+        "eslint": "^8.55.0",
+        "eslint-config-prettier": "^9.1.0",
+        "eslint-plugin-prettier": "^5.0.1",
+        "jest": "^29.7.0",
+        "prettier": "^3.1.0",
+        "rimraf": "^5.0.5",
+        "ts-jest": "^29.1.1",
+        "typescript": "^4.7.4"
       },
       "funding": {
         "type": "kofi",
@@ -1392,7 +1423,8 @@
     "node_modules/@leichtgewicht/ip-codec": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.3.tgz",
-      "integrity": "sha512-nkalE/f1RvRGChwBnEIoBfSEYOXnCRdleKuv6+lePbMDrMZXeDQnqak5XDOeBgrPPyPfAdcCu/B5z+v3VhplGg=="
+      "integrity": "sha512-nkalE/f1RvRGChwBnEIoBfSEYOXnCRdleKuv6+lePbMDrMZXeDQnqak5XDOeBgrPPyPfAdcCu/B5z+v3VhplGg==",
+      "dev": true
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -1524,14 +1556,6 @@
         "@babel/types": "^7.20.7"
       }
     },
-    "node_modules/@types/dns-packet": {
-      "version": "5.6.4",
-      "resolved": "https://registry.npmjs.org/@types/dns-packet/-/dns-packet-5.6.4.tgz",
-      "integrity": "sha512-R0ORTvCCeujG+upKfV4JlvozKLdQWlpsducXGd1L6ezBChwpjSj9K84F+KoMDsZQ9RhOLTR1hnNrwJHWagY24g==",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.9",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
@@ -1581,19 +1605,11 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true
     },
-    "node_modules/@types/multicast-dns": {
-      "version": "7.2.4",
-      "resolved": "https://registry.npmjs.org/@types/multicast-dns/-/multicast-dns-7.2.4.tgz",
-      "integrity": "sha512-ib5K4cIDR4Ro5SR3Sx/LROkMDa0BHz0OPaCBL/OSPDsAXEGZ3/KQeS6poBKYVN7BfjXDL9lWNwzyHVgt/wkyCw==",
-      "dependencies": {
-        "@types/dns-packet": "*",
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/node": {
       "version": "20.10.4",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.4.tgz",
       "integrity": "sha512-D08YG6rr8X90YB56tSIuBaddy/UXAA9RKJoFvrsnogAum/0pmjkgi4+2nx96A330FmioegBWmEYQ+syqCFaveg==",
+      "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -2634,6 +2650,7 @@
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.3.1.tgz",
       "integrity": "sha512-spBwIj0TK0Ey3666GwIdWVfUpLyubpU53BTCu8iPn4r4oXd9O14Hjg3EHw3ts2oed77/SeckunUYCyRlSngqHw==",
+      "dev": true,
       "dependencies": {
         "@leichtgewicht/ip-codec": "^2.0.1"
       },
@@ -2980,11 +2997,6 @@
         "through": "^2.3.8"
       }
     },
-    "node_modules/eventemitter3": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
-      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
-    },
     "node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -3084,7 +3096,8 @@
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
     },
     "node_modules/fast-diff": {
       "version": "1.3.0",
@@ -4894,11 +4907,6 @@
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true
     },
-    "node_modules/json-rpc-2.0": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/json-rpc-2.0/-/json-rpc-2.0-1.7.0.tgz",
-      "integrity": "sha512-asnLgC1qD5ytP+fvBP8uL0rvj+l8P6iYICbzZ8dVxCpESffVjzA7KkYkbKCIbavs7cllwH1ZUaNtJwphdeRqpg=="
-    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -5136,6 +5144,7 @@
       "version": "7.2.5",
       "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-7.2.5.tgz",
       "integrity": "sha512-2eznPJP8z2BFLX50tf0LuODrpINqP1RVIm/CObbTcBRITQgmC/TjcREF1NeTBzIcR5XO/ukWo+YHOjBbFwIupg==",
+      "dev": true,
       "dependencies": {
         "dns-packet": "^5.2.2",
         "thunky": "^1.0.2"
@@ -5963,21 +5972,8 @@
       }
     },
     "node_modules/shellies-ds9": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/shellies-ds9/-/shellies-ds9-1.0.5.tgz",
-      "integrity": "sha512-Rzat8aPwvwNFIryLK0xmJy0TuZDzAh2QSMIKBzpt0ZrkxFh3mLIXQFNSqfgQGSpQLkKXeQwuSi0qy8TRhYcltw==",
-      "dependencies": {
-        "@types/multicast-dns": "^7.2.4",
-        "eventemitter3": "^5.0.1",
-        "fast-deep-equal": "^3.1.3",
-        "json-rpc-2.0": "^1.7.0",
-        "multicast-dns": "^7.2.5",
-        "ws": "^8.14.2"
-      },
-      "funding": {
-        "type": "kofi",
-        "url": "https://ko-fi.com/cubi1337"
-      }
+      "resolved": "../node-shellies-ds9",
+      "link": true
     },
     "node_modules/side-channel": {
       "version": "1.0.4",
@@ -6260,7 +6256,8 @@
     "node_modules/thunky": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
-      "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA=="
+      "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
+      "dev": true
     },
     "node_modules/titleize": {
       "version": "3.0.0",
@@ -6417,7 +6414,8 @@
     "node_modules/undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
     },
     "node_modules/universalify": {
       "version": "2.0.0",
@@ -6592,26 +6590,6 @@
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/ws": {
-      "version": "8.14.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.14.2.tgz",
-      "integrity": "sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
       }
     },
     "node_modules/xml2js": {
@@ -7725,7 +7703,8 @@
     "@leichtgewicht/ip-codec": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.3.tgz",
-      "integrity": "sha512-nkalE/f1RvRGChwBnEIoBfSEYOXnCRdleKuv6+lePbMDrMZXeDQnqak5XDOeBgrPPyPfAdcCu/B5z+v3VhplGg=="
+      "integrity": "sha512-nkalE/f1RvRGChwBnEIoBfSEYOXnCRdleKuv6+lePbMDrMZXeDQnqak5XDOeBgrPPyPfAdcCu/B5z+v3VhplGg==",
+      "dev": true
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -7839,14 +7818,6 @@
         "@babel/types": "^7.20.7"
       }
     },
-    "@types/dns-packet": {
-      "version": "5.6.4",
-      "resolved": "https://registry.npmjs.org/@types/dns-packet/-/dns-packet-5.6.4.tgz",
-      "integrity": "sha512-R0ORTvCCeujG+upKfV4JlvozKLdQWlpsducXGd1L6ezBChwpjSj9K84F+KoMDsZQ9RhOLTR1hnNrwJHWagY24g==",
-      "requires": {
-        "@types/node": "*"
-      }
-    },
     "@types/graceful-fs": {
       "version": "4.1.9",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
@@ -7896,19 +7867,11 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true
     },
-    "@types/multicast-dns": {
-      "version": "7.2.4",
-      "resolved": "https://registry.npmjs.org/@types/multicast-dns/-/multicast-dns-7.2.4.tgz",
-      "integrity": "sha512-ib5K4cIDR4Ro5SR3Sx/LROkMDa0BHz0OPaCBL/OSPDsAXEGZ3/KQeS6poBKYVN7BfjXDL9lWNwzyHVgt/wkyCw==",
-      "requires": {
-        "@types/dns-packet": "*",
-        "@types/node": "*"
-      }
-    },
     "@types/node": {
       "version": "20.10.4",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.4.tgz",
       "integrity": "sha512-D08YG6rr8X90YB56tSIuBaddy/UXAA9RKJoFvrsnogAum/0pmjkgi4+2nx96A330FmioegBWmEYQ+syqCFaveg==",
+      "dev": true,
       "requires": {
         "undici-types": "~5.26.4"
       }
@@ -8632,6 +8595,7 @@
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.3.1.tgz",
       "integrity": "sha512-spBwIj0TK0Ey3666GwIdWVfUpLyubpU53BTCu8iPn4r4oXd9O14Hjg3EHw3ts2oed77/SeckunUYCyRlSngqHw==",
+      "dev": true,
       "requires": {
         "@leichtgewicht/ip-codec": "^2.0.1"
       }
@@ -8881,11 +8845,6 @@
         "through": "^2.3.8"
       }
     },
-    "eventemitter3": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
-      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
-    },
     "execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -8963,7 +8922,8 @@
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
     },
     "fast-diff": {
       "version": "1.3.0",
@@ -10294,11 +10254,6 @@
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true
     },
-    "json-rpc-2.0": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/json-rpc-2.0/-/json-rpc-2.0-1.7.0.tgz",
-      "integrity": "sha512-asnLgC1qD5ytP+fvBP8uL0rvj+l8P6iYICbzZ8dVxCpESffVjzA7KkYkbKCIbavs7cllwH1ZUaNtJwphdeRqpg=="
-    },
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -10483,6 +10438,7 @@
       "version": "7.2.5",
       "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-7.2.5.tgz",
       "integrity": "sha512-2eznPJP8z2BFLX50tf0LuODrpINqP1RVIm/CObbTcBRITQgmC/TjcREF1NeTBzIcR5XO/ukWo+YHOjBbFwIupg==",
+      "dev": true,
       "requires": {
         "dns-packet": "^5.2.2",
         "thunky": "^1.0.2"
@@ -11052,15 +11008,25 @@
       "dev": true
     },
     "shellies-ds9": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/shellies-ds9/-/shellies-ds9-1.0.5.tgz",
-      "integrity": "sha512-Rzat8aPwvwNFIryLK0xmJy0TuZDzAh2QSMIKBzpt0ZrkxFh3mLIXQFNSqfgQGSpQLkKXeQwuSi0qy8TRhYcltw==",
+      "version": "file:../node-shellies-ds9",
       "requires": {
+        "@types/jest": "^29.5.11",
         "@types/multicast-dns": "^7.2.4",
+        "@typescript-eslint/eslint-plugin": "^6.13.2",
+        "@typescript-eslint/parser": "^6.13.2",
+        "eslint": "^8.55.0",
+        "eslint-config-prettier": "^9.1.0",
+        "eslint-plugin-prettier": "^5.0.1",
         "eventemitter3": "^5.0.1",
         "fast-deep-equal": "^3.1.3",
+        "homebridge-shelly-ds9": "file:../homebridge-shelly-ds9",
+        "jest": "^29.7.0",
         "json-rpc-2.0": "^1.7.0",
         "multicast-dns": "^7.2.5",
+        "prettier": "^3.1.0",
+        "rimraf": "^5.0.5",
+        "ts-jest": "^29.1.1",
+        "typescript": "^4.7.4",
         "ws": "^8.14.2"
       }
     },
@@ -11279,7 +11245,8 @@
     "thunky": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
-      "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA=="
+      "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
+      "dev": true
     },
     "titleize": {
       "version": "3.0.0",
@@ -11373,7 +11340,8 @@
     "undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
     },
     "universalify": {
       "version": "2.0.0",
@@ -11508,12 +11476,6 @@
         "imurmurhash": "^0.1.4",
         "signal-exit": "^3.0.7"
       }
-    },
-    "ws": {
-      "version": "8.14.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.14.2.tgz",
-      "integrity": "sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==",
-      "requires": {}
     },
     "xml2js": {
       "version": "0.5.0",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,6 @@
     "prettier": "^3.1.0"
   },
   "dependencies": {
-    "shellies-ds9": "^1.0.5"
+    "shellies-ds9": "^1.0.6"
   }
 }

--- a/src/abilities/index.ts
+++ b/src/abilities/index.ts
@@ -2,6 +2,7 @@ export * from './base';
 
 export * from './accessory-information';
 export * from './cover';
+export * from './light';
 export * from './outlet';
 export * from './power-meter';
 export * from './readonly-switch';

--- a/src/abilities/light.ts
+++ b/src/abilities/light.ts
@@ -1,0 +1,100 @@
+import { CharacteristicValue } from 'homebridge';
+import { CharacteristicValue as ShelliesCharacteristicValue, Light } from 'shellies-ds9';
+
+import { Ability, ServiceClass } from './base';
+
+export class LightAbility extends Ability {
+  /**
+   * @param component - The light component to control.
+   */
+  constructor(readonly component: Light) {
+    super(
+      `Light ${component.id + 1}`,
+      `light-${component.id}`,
+    );
+
+  }
+
+  protected get serviceClass(): ServiceClass {
+    return this.Service.Lightbulb;
+  }
+
+  protected initialize() {
+    // set the initial value
+    this.service.setCharacteristic(
+      this.Characteristic.On,
+      this.component.output,
+    );
+
+    // listen for commands from HomeKit
+    this.service.getCharacteristic(this.Characteristic.On)
+      .onSet(this.onSetHandler.bind(this));
+
+    // listen for updates from the device
+    this.component.on('change:output', this.outputChangeHandler, this);
+  }
+
+  detach() {
+    this.component.off('change:output', this.outputChangeHandler, this);
+  }
+
+  /**
+   * Handles changes to the Light.On characteristic.
+   */
+  protected async onSetHandler(value: CharacteristicValue) {
+    if (value === this.component.output) {
+      return;
+    }
+
+    try {
+      await this.component.set(value as boolean);
+    } catch (e) {
+      this.log.error(
+        'Failed to set light:',
+        e instanceof Error ? e.message : e,
+      );
+      throw this.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE;
+    }
+  }
+
+  /**
+   * Handles changes to the `output` property.
+   */
+  protected outputChangeHandler(value: ShelliesCharacteristicValue) {
+    if(value){
+      this.log.info('Light Status('+this.component.id+'): on');
+    }else{
+      this.log.info('Light Status('+this.component.id+'): off');
+    }
+    this.service.getCharacteristic(this.Characteristic.On)
+      .updateValue(value as boolean);
+  }
+
+  /**
+   * Handles changes to the Light.Brightness characteristic.
+   */
+  protected async brightnessSetHandler(value: CharacteristicValue) {
+    if (value === this.component.brightness) {
+      return;
+    }
+
+    try {
+      await this.component.set(undefined, value as number);
+    } catch (e) {
+      this.log.error(
+        'Failed to set light:',
+        e instanceof Error ? e.message : e,
+      );
+      throw this.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE;
+    }
+  }
+
+  /**
+   * Handles changes to the `brightness` property.
+   */
+  protected brightnessChangeHandler(value: ShelliesCharacteristicValue) {
+    this.log.info('Light Status('+this.component.id+'): '+value);
+    this.service.getCharacteristic(this.Characteristic.Brightness)
+      .updateValue(value as number);
+  }
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -73,6 +73,13 @@ export interface CoverOptions {
   type?: 'door' | 'window' | 'windowCovering';
 }
 
+export interface LightOptions {
+  /**
+   * Whether this light should be excluded.
+   */
+  exclude?: boolean;
+}
+
 export interface DeviceOptions {
   /**
    * The name of the device.

--- a/src/device-delegates/base.ts
+++ b/src/device-delegates/base.ts
@@ -1,4 +1,4 @@
-import { ComponentLike, Cover, Device, Switch } from 'shellies-ds9';
+import { ComponentLike, Cover, Device, Switch, Light } from 'shellies-ds9';
 import { PlatformAccessory } from 'homebridge';
 
 import {
@@ -8,10 +8,11 @@ import {
   OutletAbility,
   PowerMeterAbility,
   SwitchAbility,
+  LightAbility,
 } from '../abilities';
 import { Accessory, AccessoryId } from '../accessory';
 import { DeviceLogger } from '../utils/device-logger';
-import { CoverOptions, DeviceOptions, SwitchOptions } from '../config';
+import { CoverOptions, DeviceOptions, SwitchOptions, LightOptions } from '../config';
 import { ShellyPlatform } from '../platform';
 
 /**
@@ -44,6 +45,17 @@ export interface AddCoverOptions {
    * Whether the accessory should be active.
    */
   active: boolean;
+}
+
+export interface AddLightOptions {
+  /**
+   * Whether the accessory should be active.
+   */
+  active: boolean;
+  /**
+   * Whether the device has a single light.
+   */
+  single: boolean;
 }
 
 /**
@@ -222,6 +234,27 @@ export abstract class DeviceDelegate {
       new CoverAbility(cover, 'window').setActive(!isDoor && !isWindowCovering),
       new PowerMeterAbility(cover),
     ).setActive(coverOpts.exclude !== true && o.active !== false);
+  }
+
+  /**
+   * Creates an accessory for a light component.
+   * @param light - The light component to use.
+   * @param opts - Options for the light.
+   */
+  protected addLight(light: Light, opts?: Partial<AddLightOptions>): Accessory {
+    const o = opts ?? {};
+
+    // get the config options for this light
+    const lightOpts = this.getComponentOptions<LightOptions>(light) ?? {};
+
+    const id = o.single === true ? 'light' : `light-${light.id}`;
+    const nameSuffix = o.single === true ? null : `Light ${light.id + 1}`;
+
+    return this.createAccessory(
+      id,
+      nameSuffix,
+      new LightAbility(light),
+    ).setActive(lightOpts.exclude !== true && o.active !== false);
   }
 
   /**

--- a/src/device-delegates/index.ts
+++ b/src/device-delegates/index.ts
@@ -12,3 +12,5 @@ export * from './shelly-pro-2';
 export * from './shelly-pro-3';
 export * from './shelly-pro-2-pm';
 export * from './shelly-pro-4-pm';
+export * from './shelly-pro-dimmer-1-pm';
+export * from './shelly-pro-dimmer-2-pm';

--- a/src/device-delegates/shelly-pro-4-pm.ts
+++ b/src/device-delegates/shelly-pro-4-pm.ts
@@ -1,4 +1,4 @@
-import { ShellyPro4Pm, ShellyPro4PmV2} from 'shellies-ds9';
+import { ShellyPro4Pm, ShellyPro4PmV2 } from 'shellies-ds9';
 
 import { DeviceDelegate } from './base';
 

--- a/src/device-delegates/shelly-pro-dimmer-1-pm.ts
+++ b/src/device-delegates/shelly-pro-dimmer-1-pm.ts
@@ -1,0 +1,16 @@
+import { ShellyProDimmer1Pm } from 'shellies-ds9';
+
+import { DeviceDelegate } from './base';
+
+/**
+ * Handles Shelly Pro Dimmer 1PM devices.
+ */
+export class ShellyProDimmer1PmDelegate extends DeviceDelegate {
+  protected setup() {
+    const d = this.device as ShellyProDimmer1Pm;
+
+    this.addLight(d.light0, { single: true });
+  }
+}
+
+DeviceDelegate.registerDelegate(ShellyProDimmer1PmDelegate, ShellyProDimmer1Pm);

--- a/src/device-delegates/shelly-pro-dimmer-2-pm.ts
+++ b/src/device-delegates/shelly-pro-dimmer-2-pm.ts
@@ -1,0 +1,17 @@
+import { ShellyProDimmer2Pm } from 'shellies-ds9';
+
+import { DeviceDelegate } from './base';
+
+/**
+ * Handles Shelly Pro Dimmer 2PM devices.
+ */
+export class ShellyProDimmer2PmDelegate extends DeviceDelegate {
+  protected setup() {
+    const d = this.device as ShellyProDimmer2Pm;
+
+    this.addLight(d.light0);
+    this.addLight(d.light1);
+  }
+}
+
+DeviceDelegate.registerDelegate(ShellyProDimmer2PmDelegate, ShellyProDimmer2Pm);


### PR DESCRIPTION
Add support for [Pro Dimmer 1PM](https://kb.shelly.cloud/knowledge-base/shelly-pro-dimmer-1pm) and [Pro Dimmer 2PM](https://kb.shelly.cloud/knowledge-base/shelly-pro-dimmer-2pm).

Requires https://github.com/cubi1337/node-shellies-ds9/pull/1