### PR TITLE
Light: implement the `brightness` characteristic to enable dimming

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homebridge-shelly-ds9",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "homebridge-shelly-ds9",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "GPL-3.0",
       "dependencies": {
         "shellies-ds9": "^1.0.6"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-shelly-ds9",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Homebridge plugin for the next generation of Shelly devices",
   "main": "dist/index.js",
   "scripts": {
@@ -12,7 +12,7 @@
     "pretty": "prettier --write \"./**/*.{js,jsx,json}\""
   },
   "engines": {
-    "node": ">=14.18.3",
+    "node": ">=18.15.0",
     "homebridge": ">=1.3.5"
   },
   "repository": {

--- a/src/abilities/light.ts
+++ b/src/abilities/light.ts
@@ -29,13 +29,17 @@ export class LightAbility extends Ability {
     // listen for commands from HomeKit
     this.service.getCharacteristic(this.Characteristic.On)
       .onSet(this.onSetHandler.bind(this));
+    this.service.getCharacteristic(this.Characteristic.Brightness)
+      .onSet(this.brightnessSetHandler.bind(this));
 
     // listen for updates from the device
     this.component.on('change:output', this.outputChangeHandler, this);
+    this.component.on('change:brightness', this.brightnessChangeHandler, this);
   }
 
   detach() {
     this.component.off('change:output', this.outputChangeHandler, this);
+    this.component.off('change:brightness', this.brightnessChangeHandler, this);
   }
 
   /**
@@ -61,7 +65,7 @@ export class LightAbility extends Ability {
    * Handles changes to the `output` property.
    */
   protected outputChangeHandler(value: ShelliesCharacteristicValue) {
-    if(value){
+    if (value){
       this.log.info('Light Status('+this.component.id+'): on');
     }else{
       this.log.info('Light Status('+this.component.id+'): off');


### PR DESCRIPTION
Version 1.2.0 exposes Pro Dimmers with one or two non-dimmable lights. I've verified that turning them on or off works as expected, so this PR also adds the brightness characteristic which should make the lights dimmable.