### PR TITLE
Update shellies-ds9 to 1.0.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.2.0",
       "license": "GPL-3.0",
       "dependencies": {
-        "shellies-ds9": "^1.0.6"
+        "shellies-ds9": "^1.0.7"
       },
       "devDependencies": {
         "@types/jest": "^29.5.11",
@@ -28,7 +28,7 @@
       },
       "engines": {
         "homebridge": ">=1.3.5",
-        "node": ">=14.18.3"
+        "node": ">=18.15.0"
       },
       "funding": {
         "type": "kofi",
@@ -37,7 +37,7 @@
     },
     "../node-shellies-ds9": {
       "name": "shellies-ds9",
-      "version": "1.0.6",
+      "version": "1.0.7",
       "license": "GPL-3.0",
       "dependencies": {
         "@types/multicast-dns": "^7.2.4",
@@ -49,16 +49,16 @@
       },
       "devDependencies": {
         "@types/jest": "^29.5.11",
-        "@typescript-eslint/eslint-plugin": "^6.13.2",
-        "@typescript-eslint/parser": "^6.13.2",
-        "eslint": "^8.55.0",
+        "@typescript-eslint/eslint-plugin": "^7.9.0",
+        "@typescript-eslint/parser": "^7.9.0",
+        "eslint": "^8.57.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-prettier": "^5.0.1",
         "jest": "^29.7.0",
         "prettier": "^3.1.0",
-        "rimraf": "^5.0.5",
+        "rimraf": "^5.0.7",
         "ts-jest": "^29.1.1",
-        "typescript": "^4.7.4"
+        "typescript": "^5.4.5"
       },
       "funding": {
         "type": "kofi",
@@ -11011,9 +11011,9 @@
       "requires": {
         "@types/jest": "^29.5.11",
         "@types/multicast-dns": "^7.2.4",
-        "@typescript-eslint/eslint-plugin": "^6.13.2",
-        "@typescript-eslint/parser": "^6.13.2",
-        "eslint": "^8.55.0",
+        "@typescript-eslint/eslint-plugin": "^7.9.0",
+        "@typescript-eslint/parser": "^7.9.0",
+        "eslint": "^8.57.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-prettier": "^5.0.1",
         "eventemitter3": "^5.0.1",
@@ -11022,9 +11022,9 @@
         "json-rpc-2.0": "^1.7.0",
         "multicast-dns": "^7.2.5",
         "prettier": "^3.1.0",
-        "rimraf": "^5.0.5",
+        "rimraf": "^5.0.7",
         "ts-jest": "^29.1.1",
-        "typescript": "^4.7.4",
+        "typescript": "^5.4.5",
         "ws": "^8.14.2"
       }
     },

--- a/package.json
+++ b/package.json
@@ -50,6 +50,6 @@
     "prettier": "^3.1.0"
   },
   "dependencies": {
-    "shellies-ds9": "^1.0.6"
+    "shellies-ds9": "^1.0.7"
   }
 }


### PR DESCRIPTION
To pick up https://github.com/cubi1337/node-shellies-ds9/pull/2.